### PR TITLE
Fix bug - script couldn't restart, time format string throws exception

### DIFF
--- a/share_war.py
+++ b/share_war.py
@@ -151,8 +151,7 @@ def deploy_share_war(n=3, order=True):
         print("[*] ERROR in Share War")
         pass
 
-
-    print("[*] the share war will continue in {} minutes...current time: {}".format(int(random_loop_time/60), time.strftime('%l:%M%p %Z on %b %d, %Y')))
+    print("[*] the share war will continue in {} minutes...current time: {}".format(int(random_loop_time/60), time.strftime("%m/%d/%Y, %H:%M:%S")))
 
 
 if __name__=="__main__":


### PR DESCRIPTION
Fixed by using a different format string to format the time output in the print statement

Could be a caused by me being on python 3.7.... idk, I'm new to this