### PR TITLE
Add support for sharing other sellers accounts

### DIFF
--- a/example_credentials.py
+++ b/example_credentials.py
@@ -1,5 +1,5 @@
 #Enter Your Credentials Here
-#poshmark_email = "myemail@gmail.com"
+#poshmark_username = "myAccountName"
 #poshmark_password = "mysupersecret"
 
 #Rename this file "credentials.py"

--- a/example_credentials.py
+++ b/example_credentials.py
@@ -1,6 +1,6 @@
 #Enter Your Credentials Here
-#poshmark_username = "myAccountName"
-#poshmark_password = "mysupersecret"
+#poshmark_username = "poshmarkusername"
+#poshmark_password = "poshmarkpassword"
 
 #Rename this file "credentials.py"
 #mv example_credentials.py credentials.py

--- a/share_war.py
+++ b/share_war.py
@@ -21,7 +21,7 @@ def login():
         #Login
         print("[*] logging into Poshmark seller account...the share war will begin momentarily...")
         username = driver.find_element_by_name("login_form[username_email]")
-        username.send_keys(poshmark_email)
+        username.send_keys(poshmark_username)
         time.sleep(rt(5))
 
         password = driver.find_element_by_name("login_form[password]")
@@ -47,7 +47,7 @@ def login():
 
         #Navigate to Seller Page
         time.sleep(rt(10))
-        seller_page = "https://poshmark.com/closet/{}?availability=available".format(poshmark_email)
+        seller_page = "https://poshmark.com/closet/{}?availability=available".format(args.account)
         driver.get(seller_page)
 
     except:
@@ -65,7 +65,7 @@ def login_pdb():
         #Login
         username = driver.find_element_by_name("login_form[username_email]")
         username.clear()
-        username.send_keys(poshmark_email)
+        username.send_keys(poshmark_username)
         time.sleep(rt(5))
 
         password = driver.find_element_by_name("login_form[password]")
@@ -75,7 +75,7 @@ def login_pdb():
 
         #Navigate to Seller Page
         time.sleep(rt(5))
-        seller_page = "https://poshmark.com/closet/{}?availability=available".format(poshmark_email)
+        seller_page = "https://poshmark.com/closet/{}?availability=available".format(args.account)
         driver.get(seller_page)
 
     except:
@@ -160,6 +160,7 @@ if __name__=="__main__":
     parser.add_argument("-t", "--time", default=3600, type=float, help="time in seconds")
     parser.add_argument("-n", "--number", default=7, type=int, help="number of closet scrolls")
     parser.add_argument("-o", "--order", default=True, type=bool, help="preserve closet order")
+    parser.add_argument("-a", "--account", default=poshmark_username, type=str, help="The accounts closet you want to share (default is the account provided in the credentials file)")
     args = parser.parse_args()
 
     #Start Share War Loop


### PR DESCRIPTION
This is useful for becoming a poshmark ambassador.

I renamed poshmark_email to poshmark_username for cleaniness. This was causing a bug when the script would try to load the users closest, but the query string will fail to load if it contains a email address. And since a username is required now, I thought it'd be best to rename it to something else.
You can now pass in an argument with the '-a' and give an alternative seller account to share